### PR TITLE
Memory lifecycle: decay, eviction, and consolidation

### DIFF
--- a/db/schema.ts
+++ b/db/schema.ts
@@ -1,4 +1,4 @@
-import { pgTable, text, serial, integer, timestamp, boolean, json, jsonb, customType } from "drizzle-orm/pg-core";
+import { pgTable, text, serial, integer, timestamp, boolean, json, jsonb, real, customType } from "drizzle-orm/pg-core";
 import { relations } from "drizzle-orm";
 import { createInsertSchema, createSelectSchema } from "drizzle-zod";
 import { sql } from "drizzle-orm";
@@ -133,6 +133,23 @@ export const memories = pgTable("memories", {
   source_message_id: integer("source_message_id").references(() => messages.id, { onDelete: "set null" }),
   confidence: integer("confidence").default(70).notNull(),
   pinned: boolean("pinned").default(false).notNull(),
+  // Lifecycle salience (decay model). Distinct from `confidence` (extractor
+  // certainty): strength decays over time and is bumped by reinforcement.
+  strength: real("strength").default(1).notNull(),
+  // FSRS-style stability: multiplies the kind's base half-life. Grows on each
+  // reinforcement (more when the memory was closer to forgotten), so
+  // repeatedly-confirmed facts become effectively permanent without pinning.
+  stability: real("stability").default(1).notNull(),
+  // Decay eviction is invalidation, not deletion (Zep-style). Set when the
+  // sweep evicts a row; active-row queries filter on IS NULL. Evicted rows
+  // can be resurrected by create-time dedup and are purged much later.
+  evicted_at: timestamp("evicted_at"),
+  // Nullable with NO default — migration 0010 backfills legacy rows from
+  // updated_at, keyed on IS NULL. A defaultNow() here would stamp every
+  // existing row at deploy time via db:push and void that backfill.
+  // Code sets it explicitly on create/supersede/reinforce; reads coalesce
+  // to updated_at ?? created_at.
+  last_reinforced_at: timestamp("last_reinforced_at"),
   superseded_by: integer("superseded_by"),
   last_used_at: timestamp("last_used_at"),
   use_count: integer("use_count").default(0).notNull(),

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -84,6 +84,13 @@ if [ $? -ne 0 ]; then
     echo "Failed to add memory indexes (may already be applied)"
 fi
 
+# Memory decay backfill + index swap (columns created by db:push above)
+echo "Applying memory decay migration..."
+psql -f migrations/0010_memory_decay.sql
+if [ $? -ne 0 ]; then
+    echo "Failed to apply memory decay migration (may already be applied)"
+fi
+
 echo "Database schema setup completed!"
 
 # Start the application

--- a/migrations/0010_memory_decay.sql
+++ b/migrations/0010_memory_decay.sql
@@ -1,0 +1,22 @@
+-- Memory decay / eviction (0010).
+-- The strength + last_reinforced_at columns are created by drizzle-kit
+-- (db:push) from db/schema.ts before this file runs. This file backfills
+-- rows that predate the decay rework and swaps indexes. Safe to re-run.
+
+-- One-time backfill: legacy rows have NULL last_reinforced_at. Seed the
+-- reinforcement clock from updated_at (so long-untouched rows start
+-- already-decayed) and strength from extractor confidence
+-- (conf 70 -> 0.85, conf 100 -> 1.0). Idempotent: application code sets
+-- last_reinforced_at on every new row, so this matches only legacy rows, once.
+UPDATE "memories"
+SET "last_reinforced_at" = "updated_at",
+    "strength" = 0.5 + LEAST(GREATEST("confidence", 0), 100) / 200.0
+WHERE "last_reinforced_at" IS NULL;
+
+-- Nothing ranks on use_count anymore (it is telemetry only).
+DROP INDEX IF EXISTS "idx_memories_user_pinned_use";
+
+-- The always-on slice is now pinned-only.
+CREATE INDEX IF NOT EXISTS "idx_memories_user_pinned_active"
+	ON "memories" ("user_id")
+	WHERE "pinned" AND "superseded_by" IS NULL;

--- a/server/memory-service.ts
+++ b/server/memory-service.ts
@@ -27,14 +27,52 @@ import { getAnthropicModel } from "./ai-sdk-providers";
 // Tunables
 // ---------------------------------------------------------------------------
 
-const ALWAYS_ON_LIMIT = 8;        // pinned + heavy-use, regardless of similarity
-const SEMANTIC_LIMIT = 8;         // top-K by cosine similarity to current message
-const SEMANTIC_THRESHOLD = 0.35;  // cosine similarity floor (0..1) — below this is noise
+const PINNED_LIMIT = 8;           // always-on slice: pinned rows only
+const SEMANTIC_LIMIT = 8;         // top-K by weighted score for current message
+const SEMANTIC_THRESHOLD = 0.35;  // raw cosine floor (0..1) — below this is noise
 const SEMANTIC_CANDIDATE_CAP = 500; // hard cap on memories we score per turn
 const RECENT_HISTORY_LIMIT = 8;
 const EXTRACTION_DEBOUNCE_MS = 5000;
 const EXTRACTOR_MODEL = "claude-haiku-4-5-20251001";
 const EMBEDDING_MODEL = "text-embedding-3-small";
+
+// --- Decay / eviction ---
+// A memory's effective strength halves every HALF_LIFE_DAYS[kind] days since
+// it was last reinforced. Pinned rows are exempt. Below STRENGTH_FLOOR a row
+// is invisible to retrieval and hard-deleted by the sweep.
+const HALF_LIFE_DAYS: Record<string, number> = {
+  open_thread: 14,
+  fact: 90,
+  entity: 90,
+  decision: 120,
+  preference: 365,
+};
+const DEFAULT_HALF_LIFE_DAYS = 90;
+const STRENGTH_FLOOR = 0.15;
+// FSRS-style stability (spaced repetition): each reinforcement multiplies the
+// row's effective half-life by (1 + GROWTH * (1 - retrievability)) — a memory
+// reinforced when nearly forgotten gains the most (the spacing effect), one
+// reinforced seconds after the last gains ~nothing. Repeatedly-confirmed
+// facts thus become effectively permanent without pinning.
+const STABILITY_GROWTH = 1.5;
+const STABILITY_CAP = 64;         // max half-life multiplier (~preference: 64y)
+// Only strong semantic hits reinforce. Marginal matches (0.35–0.55) are still
+// injected but do NOT reset the clock — otherwise the rich-get-richer loop
+// reappears through the semantic path.
+const REINFORCE_MIN_SIMILARITY = 0.55;
+// Additive retrieval ranking (Stanford generative-agents style): weighted sum
+// is more robust than a product when one signal is noisy.
+const RANK_WEIGHT_SIMILARITY = 0.7;
+const RANK_WEIGHT_STRENGTH = 0.3;
+const DEDUP_SUPERSEDE_THRESHOLD = 0.88; // same-kind cosine: create becomes supersede
+const DEDUP_IDENTICAL_THRESHOLD = 0.95; // same-kind cosine: create becomes reinforce
+const PURGE_SUPERSEDED_AFTER_DAYS = 30; // recovery window for bad supersede chains
+const PURGE_EVICTED_AFTER_DAYS = 180;   // evicted (invalidated) rows linger this long
+const REEMBED_BATCH = 5;                // null-embedding rows re-embedded per sweep
+const CONSOLIDATE_EVERY_N_EXTRACTIONS = 10;
+const CONSOLIDATE_ACTIVE_THRESHOLD = 60; // ...or when active count exceeds this
+const EXTRACTOR_CONTEXT_SIMILAR = 20;   // similarity-ranked memories shown to extractor
+const EXTRACTOR_CONTEXT_RECENT = 10;    // plus most-recent, plus all pinned
 
 // ---------------------------------------------------------------------------
 // Embedding helper
@@ -84,6 +122,44 @@ function cosineSimilarity(a: number[], b: number[]): number {
 }
 
 // ---------------------------------------------------------------------------
+// Decay model
+// ---------------------------------------------------------------------------
+
+type MemoryRow = typeof memories.$inferSelect;
+
+/** Seed strength from extractor confidence: conf 70 → 0.85, conf 100 → 1.0. */
+function seedStrength(confidence: number): number {
+  return 0.5 + Math.min(100, Math.max(0, confidence)) / 200;
+}
+
+function reinforcedAt(m: Pick<MemoryRow, "last_reinforced_at" | "updated_at" | "created_at">): Date {
+  return m.last_reinforced_at ?? m.updated_at ?? m.created_at;
+}
+
+/** Kind's base half-life times the row's earned stability multiplier. */
+function effectiveHalfLifeDays(m: Pick<MemoryRow, "kind" | "stability">): number {
+  return (HALF_LIFE_DAYS[m.kind] ?? DEFAULT_HALF_LIFE_DAYS) * Math.max(1, m.stability);
+}
+
+/** Decay fraction in (0, 1]: 0.5^(days_since_reinforced / effective_half_life). */
+function retrievability(m: MemoryRow): number {
+  const ageDays = Math.max(0, Date.now() - reinforcedAt(m).getTime()) / 86_400_000;
+  return Math.pow(0.5, ageDays / effectiveHalfLifeDays(m));
+}
+
+/** strength * retrievability. Pinned rows don't decay. */
+function effectiveStrength(m: MemoryRow): number {
+  if (m.pinned) return m.strength;
+  return m.strength * retrievability(m);
+}
+
+// The eviction sweep needs the same decay formula in SQL. Generate the
+// half-life CASE from HALF_LIFE_DAYS so the TS and SQL versions can't drift.
+const HALF_LIFE_CASE_SQL = `CASE "kind" ${Object.entries(HALF_LIFE_DAYS)
+  .map(([kind, days]) => `WHEN '${kind}' THEN ${days}`)
+  .join(" ")} ELSE ${DEFAULT_HALF_LIFE_DAYS} END`;
+
+// ---------------------------------------------------------------------------
 // Retrieval
 // ---------------------------------------------------------------------------
 
@@ -100,13 +176,13 @@ export async function retrieveForTurn(
   userId: number,
   opts: MemoryRetrievalOpts = {},
 ): Promise<string> {
-  const [alwaysOn, semantic] = await Promise.all([
-    fetchAlwaysOn(userId),
+  const [pinned, semantic] = await Promise.all([
+    fetchPinned(userId),
     fetchSemanticMatched(userId, opts.latestUserMessage),
   ]);
 
   const seen = new Set<number>();
-  const all = [...alwaysOn, ...semantic].filter((m) => {
+  const all = [...pinned, ...semantic.map((s) => s.row)].filter((m) => {
     if (seen.has(m.id)) return false;
     seen.add(m.id);
     return true;
@@ -115,27 +191,48 @@ export async function retrieveForTurn(
   if (all.length === 0) return "";
 
   void touchUsage(all.map((m) => m.id)).catch(() => {});
+  // Only strong semantic hits reset the decay clock. Pinned injection is
+  // deliberately NOT a reinforcement signal — that was the rich-get-richer bug.
+  const strongHits = semantic
+    .filter((s) => s.similarity >= REINFORCE_MIN_SIMILARITY)
+    .map((s) => s.row.id);
+  void reinforceMemories(strongHits, userId).catch(() => {});
   return formatMemoryBlock(all);
 }
 
-async function fetchAlwaysOn(userId: number) {
+async function fetchPinned(userId: number) {
   return db
     .select()
     .from(memories)
-    .where(and(eq(memories.user_id, userId), isNull(memories.superseded_by)))
-    .orderBy(desc(memories.pinned), desc(memories.use_count), desc(memories.updated_at))
-    .limit(ALWAYS_ON_LIMIT);
+    .where(
+      and(
+        eq(memories.user_id, userId),
+        eq(memories.pinned, true),
+        isNull(memories.superseded_by),
+        isNull(memories.evicted_at),
+      ),
+    )
+    .orderBy(desc(memories.updated_at))
+    .limit(PINNED_LIMIT);
 }
 
 /**
  * Embed the latest user message once, score all active memories with embeddings
  * by cosine similarity, return the top hits above SEMANTIC_THRESHOLD.
  *
+ * Ranking is an additive weighted sum (generative-agents style): rank =
+ * 0.7 * cosine + 0.3 * min(1, effective strength), so a decayed exact match
+ * still beats fresh noise. Rows below STRENGTH_FLOOR are invisible (the
+ * sweep will invalidate them).
+ *
  * This scans up to SEMANTIC_CANDIDATE_CAP memories per turn. Fine for v1
  * (a single user accumulating thousands of memories is unlikely soon). When
  * it stops being fine, switch to pgvector + IVFFlat.
  */
-async function fetchSemanticMatched(userId: number, latestUserMessage?: string) {
+async function fetchSemanticMatched(
+  userId: number,
+  latestUserMessage?: string,
+): Promise<Array<{ row: MemoryRow; similarity: number }>> {
   if (!latestUserMessage) return [];
   const queryVec = await embedText(latestUserMessage);
   if (!queryVec) return [];
@@ -147,13 +244,14 @@ async function fetchSemanticMatched(userId: number, latestUserMessage?: string) 
       and(
         eq(memories.user_id, userId),
         isNull(memories.superseded_by),
+        isNull(memories.evicted_at),
         isNotNull(memories.embedding),
       ),
     )
     .orderBy(desc(memories.updated_at))
     .limit(SEMANTIC_CANDIDATE_CAP);
 
-  const scored: Array<{ row: typeof candidates[number]; score: number }> = [];
+  const scored: Array<{ row: MemoryRow; similarity: number; rank: number }> = [];
   for (const row of candidates) {
     if (!row.embedding) continue;
     let vec: number[];
@@ -162,12 +260,44 @@ async function fetchSemanticMatched(userId: number, latestUserMessage?: string) 
     } catch {
       continue;
     }
-    const score = cosineSimilarity(queryVec, vec);
-    if (score >= SEMANTIC_THRESHOLD) scored.push({ row, score });
+    const similarity = cosineSimilarity(queryVec, vec);
+    if (similarity < SEMANTIC_THRESHOLD) continue;
+    const eff = effectiveStrength(row);
+    if (eff < STRENGTH_FLOOR) continue;
+    const rank =
+      RANK_WEIGHT_SIMILARITY * similarity + RANK_WEIGHT_STRENGTH * Math.min(1, eff);
+    scored.push({ row, similarity, rank });
   }
 
-  scored.sort((a, b) => b.score - a.score);
-  return scored.slice(0, SEMANTIC_LIMIT).map((s) => s.row);
+  scored.sort((a, b) => b.rank - a.rank);
+  return scored.slice(0, SEMANTIC_LIMIT).map(({ row, similarity }) => ({ row, similarity }));
+}
+
+/**
+ * Reset the decay clock and grow stability for genuinely-relevant rows.
+ * Spacing effect: the closer a memory was to forgotten (low retrievability),
+ * the bigger its stability gain; back-to-back reinforcement gains ~nothing.
+ */
+async function reinforceMemories(ids: number[], userId: number) {
+  if (ids.length === 0) return;
+  const rows = await db
+    .select()
+    .from(memories)
+    .where(and(inArray(memories.id, ids), eq(memories.user_id, userId)));
+  const now = new Date();
+  for (const row of rows) {
+    const r = row.pinned ? 1 : retrievability(row);
+    const grown = Math.min(
+      STABILITY_CAP,
+      Math.max(1, row.stability) * (1 + STABILITY_GROWTH * (1 - r)),
+    );
+    // Does NOT touch updated_at: reinforcement isn't an edit, and updated_at
+    // anchors the legacy-backfill coalesce in reinforcedAt().
+    await db
+      .update(memories)
+      .set({ last_reinforced_at: now, stability: grown })
+      .where(eq(memories.id, row.id));
+  }
 }
 
 function formatMemoryBlock(rows: Array<{ kind: string; body: string }>): string {
@@ -205,12 +335,56 @@ function formatMemoryBlock(rows: Array<{ kind: string; body: string }>): string 
   return `${preamble}\n\n${sections.join("\n\n")}`;
 }
 
+// Pure telemetry since the decay rework — nothing ranks on use_count anymore.
 async function touchUsage(ids: number[]) {
   if (ids.length === 0) return;
   await db
     .update(memories)
     .set({ last_used_at: new Date(), use_count: sql`${memories.use_count} + 1` })
     .where(inArray(memories.id, ids));
+}
+
+/**
+ * Semantic lookup over a user's active memories — backs the forget_memory
+ * tool. Unlike fetchSemanticMatched, this applies no strength floor or
+ * ranking weights: the caller wants raw "which memory says this?" matches.
+ */
+export async function findMemoriesByQuery(
+  userId: number,
+  query: string,
+  opts: { limit?: number; minSimilarity?: number } = {},
+): Promise<Array<{ row: MemoryRow; similarity: number }>> {
+  const limit = opts.limit ?? 5;
+  const minSimilarity = opts.minSimilarity ?? 0.5;
+  const queryVec = await embedText(query);
+  if (!queryVec) return [];
+
+  const candidates = await db
+    .select()
+    .from(memories)
+    .where(
+      and(
+        eq(memories.user_id, userId),
+        isNull(memories.superseded_by),
+        isNull(memories.evicted_at),
+        isNotNull(memories.embedding),
+      ),
+    )
+    .orderBy(desc(memories.updated_at))
+    .limit(SEMANTIC_CANDIDATE_CAP);
+
+  const scored: Array<{ row: MemoryRow; similarity: number }> = [];
+  for (const row of candidates) {
+    if (!row.embedding) continue;
+    try {
+      const similarity = cosineSimilarity(queryVec, JSON.parse(row.embedding));
+      if (similarity >= minSimilarity) scored.push({ row, similarity });
+    } catch {
+      continue;
+    }
+  }
+  scored.sort((a, b) => b.similarity - a.similarity);
+  return scored.slice(0, limit);
 }
 
 // ---------------------------------------------------------------------------
@@ -288,6 +462,54 @@ function snippet(content: string, query: string): string {
 // CRUD
 // ---------------------------------------------------------------------------
 
+/**
+ * Same-kind mechanical dedup. Returns the best match at or above
+ * DEDUP_SUPERSEDE_THRESHOLD, or null. Same-kind only: cross-kind matching
+ * would let a `fact` clobber a semantically-near `preference`.
+ *
+ * Deliberately searches EVICTED rows too — re-stating a decayed-out fact is
+ * the resurrection path (the caller clears evicted_at).
+ */
+async function findSameKindDuplicate(
+  userId: number,
+  kind: MemoryRow["kind"],
+  vec: number[],
+): Promise<{ row: MemoryRow; similarity: number } | null> {
+  const candidates = await db
+    .select()
+    .from(memories)
+    .where(
+      and(
+        eq(memories.user_id, userId),
+        eq(memories.kind, kind),
+        isNull(memories.superseded_by),
+        isNotNull(memories.embedding),
+      ),
+    )
+    .orderBy(desc(memories.updated_at))
+    .limit(SEMANTIC_CANDIDATE_CAP);
+
+  let best: MemoryRow | null = null;
+  let bestScore = 0;
+  for (const row of candidates) {
+    if (!row.embedding) continue;
+    let rowVec: number[];
+    try {
+      rowVec = JSON.parse(row.embedding);
+    } catch {
+      continue;
+    }
+    const score = cosineSimilarity(vec, rowVec);
+    if (score > bestScore) {
+      bestScore = score;
+      best = row;
+    }
+  }
+  return best && bestScore >= DEDUP_SUPERSEDE_THRESHOLD
+    ? { row: best, similarity: bestScore }
+    : null;
+}
+
 export async function createMemory(input: {
   userId: number;
   kind: "preference" | "fact" | "decision" | "open_thread" | "entity";
@@ -298,6 +520,52 @@ export async function createMemory(input: {
   sourceMessageId?: number;
 }) {
   const vec = await embedText(input.body);
+
+  // Mechanical dedup: a near-identical active memory means this "create" is
+  // really a restatement. >= 0.95: reinforce the existing row. 0.88–0.95:
+  // supersede it with the fresh phrasing. No embedding -> no dedup, insert.
+  if (vec) {
+    const match = await findSameKindDuplicate(input.userId, input.kind, vec);
+    if (match) {
+      // Resurrection: the fact decayed out but the user brought it up again.
+      // Reactivate before the normal reinforce/supersede handling.
+      if (match.row.evicted_at) {
+        await db
+          .update(memories)
+          .set({ evicted_at: null, last_reinforced_at: new Date() })
+          .where(eq(memories.id, match.row.id));
+        match.row.evicted_at = null;
+        console.log(`[memory] resurrected evicted memory ${match.row.id} for user ${input.userId}`);
+      }
+      let surviving: MemoryRow | null;
+      if (match.similarity >= DEDUP_IDENTICAL_THRESHOLD) {
+        await reinforceMemories([match.row.id], input.userId);
+        surviving = match.row;
+      } else {
+        surviving = await supersedeMemory(
+          match.row.id,
+          input.body,
+          {
+            userId: input.userId,
+            conversationId: input.sourceConversationId,
+            messageId: input.sourceMessageId,
+          },
+          vec,
+        );
+      }
+      if (surviving) {
+        // Don't silently drop an explicit pin on the incoming fact.
+        if (input.pinned && !surviving.pinned) {
+          await db
+            .update(memories)
+            .set({ pinned: true, updated_at: new Date() })
+            .where(eq(memories.id, surviving.id));
+        }
+        return surviving;
+      }
+    }
+  }
+
   const [row] = await db
     .insert(memories)
     .values({
@@ -307,6 +575,9 @@ export async function createMemory(input: {
       embedding: vec ? JSON.stringify(vec) : null,
       confidence: input.confidence ?? 70,
       pinned: input.pinned ?? false,
+      strength: seedStrength(input.confidence ?? 70),
+      stability: 1,
+      last_reinforced_at: new Date(),
       source_conversation_id: input.sourceConversationId,
       source_message_id: input.sourceMessageId,
     })
@@ -318,8 +589,9 @@ export async function supersedeMemory(
   oldId: number,
   newBody: string,
   ctx: { userId: number; conversationId?: number; messageId?: number },
+  precomputedVec?: number[] | null,
 ) {
-  const vec = await embedText(newBody);
+  const vec = precomputedVec ?? (await embedText(newBody));
   return db.transaction(async (tx) => {
     const [old] = await tx
       .select()
@@ -336,6 +608,10 @@ export async function supersedeMemory(
         embedding: vec ? JSON.stringify(vec) : null,
         confidence: old.confidence,
         pinned: old.pinned,
+        // Re-confirmation restores full strength and carries earned stability.
+        strength: Math.max(1, old.strength),
+        stability: Math.max(1, old.stability),
+        last_reinforced_at: new Date(),
         source_conversation_id: ctx.conversationId,
         source_message_id: ctx.messageId,
       })
@@ -352,6 +628,55 @@ export async function deleteMemory(id: number, userId: number) {
   await db.delete(memories).where(and(eq(memories.id, id), eq(memories.user_id, userId)));
 }
 
+/**
+ * Reflection primitive: fold >=2 active source rows into one synthesized row
+ * (generative-agents style). Sources are marked superseded by the new row —
+ * lineage preserved, nothing deleted. The synthesis may change kind (e.g.
+ * several completed open_threads generalize into one fact).
+ */
+export async function mergeMemories(input: {
+  userId: number;
+  kind: MemoryRow["kind"];
+  body: string;
+  sourceIds: number[];
+}): Promise<MemoryRow | null> {
+  const vec = await embedText(input.body);
+  return db.transaction(async (tx) => {
+    const sources = await tx
+      .select()
+      .from(memories)
+      .where(
+        and(
+          inArray(memories.id, input.sourceIds),
+          eq(memories.user_id, input.userId),
+          isNull(memories.superseded_by),
+        ),
+      );
+    if (sources.length < 2) return null;
+    const [created] = await tx
+      .insert(memories)
+      .values({
+        user_id: input.userId,
+        kind: input.kind,
+        body: input.body,
+        embedding: vec ? JSON.stringify(vec) : null,
+        confidence: Math.max(...sources.map((s) => s.confidence)),
+        pinned: sources.some((s) => s.pinned),
+        strength: Math.max(1, ...sources.map((s) => s.strength)),
+        // The synthesis inherits the longest-lived source's earned stability —
+        // a pattern distilled from several confirmations is not a fresh fact.
+        stability: Math.max(1, ...sources.map((s) => s.stability)),
+        last_reinforced_at: new Date(),
+      })
+      .returning();
+    await tx
+      .update(memories)
+      .set({ superseded_by: created.id, updated_at: new Date() })
+      .where(inArray(memories.id, sources.map((s) => s.id)));
+    return created;
+  });
+}
+
 // ---------------------------------------------------------------------------
 // Background extraction
 // ---------------------------------------------------------------------------
@@ -363,6 +688,10 @@ const pendingExtractions = new Map<number, NodeJS.Timeout>();
 // In-memory only — a restart triggers one wasted extraction per active
 // conversation, which is much cheaper than a schema migration would be.
 const lastExtractedUserMsgId = new Map<number, number>();
+
+// Per-user counter driving the periodic consolidation janitor. In-memory only,
+// same trade-off as above: a restart just delays the next janitor pass.
+const extractionsSinceConsolidation = new Map<number, number>();
 
 /**
  * Debounced fire-and-forget extractor trigger. Safe to call multiple times
@@ -382,12 +711,60 @@ export function scheduleExtraction(conversationId: number, userId: number) {
 }
 
 interface ExtractorOp {
-  op: "create" | "supersede" | "delete";
+  op: "create" | "supersede" | "delete" | "reinforce" | "merge";
   id?: number;
+  /** merge (janitor only): active source rows folded into the new body. */
+  ids?: number[];
   kind?: "preference" | "fact" | "decision" | "open_thread" | "entity";
   body?: string;
   confidence?: number;
   pinned?: boolean;
+}
+
+/**
+ * Existing-memory context shown to the extractor: all pinned rows, the most
+ * recent rows, and the rows most similar to the conversation tail (Mem0-style
+ * routing context). Recency alone made the extractor blind to older
+ * duplicates — similarity is what dedup decisions actually need.
+ */
+async function fetchExtractorContext(userId: number, transcript: string): Promise<MemoryRow[]> {
+  const active = await db
+    .select()
+    .from(memories)
+    .where(
+      and(
+        eq(memories.user_id, userId),
+        isNull(memories.superseded_by),
+        isNull(memories.evicted_at),
+      ),
+    )
+    .orderBy(desc(memories.updated_at))
+    .limit(SEMANTIC_CANDIDATE_CAP);
+
+  // Small corpora fit wholesale — no need to rank.
+  if (active.length <= EXTRACTOR_CONTEXT_SIMILAR + EXTRACTOR_CONTEXT_RECENT) {
+    return active;
+  }
+
+  const picked = new Map<number, MemoryRow>();
+  for (const m of active) if (m.pinned) picked.set(m.id, m);
+  for (const m of active.slice(0, EXTRACTOR_CONTEXT_RECENT)) picked.set(m.id, m);
+
+  const queryVec = await embedText(transcript.slice(-6000));
+  if (queryVec) {
+    const scored: Array<{ m: MemoryRow; score: number }> = [];
+    for (const m of active) {
+      if (!m.embedding || picked.has(m.id)) continue;
+      try {
+        scored.push({ m, score: cosineSimilarity(queryVec, JSON.parse(m.embedding)) });
+      } catch {
+        continue;
+      }
+    }
+    scored.sort((a, b) => b.score - a.score);
+    for (const { m } of scored.slice(0, EXTRACTOR_CONTEXT_SIMILAR)) picked.set(m.id, m);
+  }
+  return Array.from(picked.values());
 }
 
 /**
@@ -423,15 +800,12 @@ export async function extractMemories(conversationId: number, userId: number): P
     .map((m) => `${m.role.toUpperCase()}: ${m.content.slice(0, 2000)}`)
     .join("\n\n");
 
-  const existing = await db
-    .select({ id: memories.id, kind: memories.kind, body: memories.body })
-    .from(memories)
-    .where(and(eq(memories.user_id, userId), isNull(memories.superseded_by)))
-    .orderBy(desc(memories.updated_at))
-    .limit(40);
+  const existing = await fetchExtractorContext(userId, transcript);
 
   const existingBlock = existing.length
-    ? existing.map((m) => `  ${m.id} [${m.kind}] ${m.body}`).join("\n")
+    ? existing
+        .map((m) => `  ${m.id} [${m.kind}]${m.pinned ? " [pinned]" : ""} ${m.body}`)
+        .join("\n")
     : "  (none)";
 
   const prompt = `You are a memory extractor for a conversational AI. Default is to save NOTHING. Only emit ops when you can name a concrete future conversation that would be worse off without this memory.
@@ -440,6 +814,9 @@ Each operation is one of:
   { "op": "create", "kind": "preference" | "fact" | "decision" | "open_thread" | "entity", "body": "<one or two sentences>", "confidence": 0-100, "pinned": true | false }
   { "op": "supersede", "id": <existing memory id>, "body": "<replacement>" }
   { "op": "delete", "id": <existing memory id> }
+  { "op": "reinforce", "id": <existing memory id> }
+
+REINFORCE when the conversation re-confirms an existing memory as accurate and still relevant — the user restated it, acted consistently with it, or it was clearly load-bearing for a good answer. Reinforce extends the memory's lifetime. Use it instead of superseding with near-identical wording, and instead of no-op when an existing memory demonstrably mattered this conversation.
 
 SAVE ONLY user-specific information that:
 - Is novel — would NOT already be known by a general-purpose LLM. Skip world facts, definitions, public knowledge, anything an LLM has in training.
@@ -480,9 +857,8 @@ Return ONLY a JSON array of operations, no commentary or markdown.`;
   try {
     const model = getAnthropicModel(EXTRACTOR_MODEL);
     const result = await generateText({ model, prompt, temperature: 0.2 });
-    const text = result.text.trim().replace(/^```json\s*/i, "").replace(/```\s*$/, "");
-    const parsed = JSON.parse(text);
-    if (!Array.isArray(parsed)) {
+    const parsed = parseOpsJson(result.text);
+    if (!parsed) {
       console.warn("[memory] extractor returned non-array, skipping");
       return;
     }
@@ -519,6 +895,8 @@ Return ONLY a JSON array of operations, no commentary or markdown.`;
         });
       } else if (op.op === "delete" && op.id) {
         await deleteMemory(op.id, userId);
+      } else if (op.op === "reinforce" && op.id) {
+        await reinforceMemories([op.id], userId);
       }
     } catch (err) {
       console.error("[memory] failed to apply op:", op, err);
@@ -532,5 +910,241 @@ Return ONLY a JSON array of operations, no commentary or markdown.`;
 
   if (ops.length > 0) {
     console.log(`[memory] applied ${ops.length} op(s) for user ${userId} from conversation ${conversationId}`);
+  }
+
+  // Lifecycle maintenance piggybacks on extraction — no separate scheduler.
+  // Runs AFTER the ops loop so the sweep can't race an op targeting a row it
+  // would delete (per-op try/catch tolerates the remaining ghosts anyway).
+  try {
+    await sweepDecayed(userId);
+  } catch (err) {
+    console.error(`[memory] sweep failed for user ${userId}:`, err);
+  }
+
+  const count = (extractionsSinceConsolidation.get(userId) ?? 0) + 1;
+  extractionsSinceConsolidation.set(userId, count);
+  if (
+    count >= CONSOLIDATE_EVERY_N_EXTRACTIONS ||
+    (await countActiveMemories(userId)) > CONSOLIDATE_ACTIVE_THRESHOLD
+  ) {
+    extractionsSinceConsolidation.set(userId, 0);
+    try {
+      await consolidateMemories(userId);
+    } catch (err) {
+      console.error(`[memory] consolidation failed for user ${userId}:`, err);
+    }
+  }
+}
+
+/** Strip an optional ```json fence and parse; null unless a JSON array. */
+function parseOpsJson(text: string): ExtractorOp[] | null {
+  const cleaned = text.trim().replace(/^```json\s*/i, "").replace(/```\s*$/, "");
+  try {
+    const parsed = JSON.parse(cleaned);
+    return Array.isArray(parsed) ? parsed : null;
+  } catch {
+    return null;
+  }
+}
+
+async function countActiveMemories(userId: number): Promise<number> {
+  const [row] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(memories)
+    .where(
+      and(
+        eq(memories.user_id, userId),
+        isNull(memories.superseded_by),
+        isNull(memories.evicted_at),
+      ),
+    );
+  return row?.count ?? 0;
+}
+
+// ---------------------------------------------------------------------------
+// Eviction sweep
+// ---------------------------------------------------------------------------
+
+/**
+ * Invalidate rows whose decayed strength fell below STRENGTH_FLOOR (Zep-style:
+ * forgetting is loss of accessibility, not erasure), purge long-dead rows,
+ * and re-embed a few embedding-less rows. Piggybacks on extraction; every
+ * step is per-user and cheap.
+ */
+export async function sweepDecayed(userId: number): Promise<void> {
+  // 1) Invalidate decayed, unpinned, active rows by stamping evicted_at.
+  //    `embedding IS NOT NULL` matters: a row that never embedded can never
+  //    be semantically reinforced, so evicting it would turn one transient
+  //    embedding-API failure at create time into guaranteed loss.
+  //    Half-life = kind base * earned stability, mirroring effectiveStrength().
+  const evicted = await db
+    .update(memories)
+    .set({ evicted_at: new Date() })
+    .where(
+      and(
+        eq(memories.user_id, userId),
+        isNull(memories.superseded_by),
+        isNull(memories.evicted_at),
+        eq(memories.pinned, false),
+        isNotNull(memories.embedding),
+        sql`${memories.strength} * power(0.5, GREATEST(0, extract(epoch from (now() - coalesce(${memories.last_reinforced_at}, ${memories.updated_at}, ${memories.created_at})))) / 86400.0 / ((${sql.raw(HALF_LIFE_CASE_SQL)}) * GREATEST(1, ${memories.stability}))) < ${STRENGTH_FLOOR}`,
+      ),
+    )
+    .returning({ id: memories.id, kind: memories.kind, body: memories.body });
+
+  // 2) Hard-purge only long-dead rows: superseded past the recovery window,
+  //    evicted rows nobody resurrected for months.
+  await db
+    .delete(memories)
+    .where(
+      and(
+        eq(memories.user_id, userId),
+        isNotNull(memories.superseded_by),
+        sql`${memories.updated_at} < now() - ${sql.raw(`interval '${PURGE_SUPERSEDED_AFTER_DAYS} days'`)}`,
+      ),
+    );
+  await db
+    .delete(memories)
+    .where(
+      and(
+        eq(memories.user_id, userId),
+        isNotNull(memories.evicted_at),
+        sql`${memories.evicted_at} < now() - ${sql.raw(`interval '${PURGE_EVICTED_AFTER_DAYS} days'`)}`,
+      ),
+    );
+
+  // 3) Opportunistically re-embed rows whose embedding call failed at create,
+  //    so they rejoin the semantic-reinforcement lifecycle.
+  const missing = await db
+    .select()
+    .from(memories)
+    .where(
+      and(
+        eq(memories.user_id, userId),
+        isNull(memories.superseded_by),
+        isNull(memories.evicted_at),
+        isNull(memories.embedding),
+      ),
+    )
+    .limit(REEMBED_BATCH);
+  for (const row of missing) {
+    const vec = await embedText(row.body);
+    if (vec) {
+      await db
+        .update(memories)
+        .set({ embedding: JSON.stringify(vec) })
+        .where(eq(memories.id, row.id));
+    }
+  }
+
+  // Tombstone log: forgetting is silent by design, but it shouldn't be
+  // untraceable. `docker compose logs` answers "what did it just forget?"
+  for (const row of evicted) {
+    console.log(`[memory] evicted (invalidated) memory ${row.id} [${row.kind}] for user ${userId}: ${row.body}`);
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Consolidation janitor
+// ---------------------------------------------------------------------------
+
+/**
+ * Periodic LLM pass over the FULL active memory list (no conversation
+ * context): merges paraphrase-duplicates the cosine dedup missed, deletes
+ * completed/stale threads, rewrites stale phrasing, and — reflection — may
+ * synthesize one higher-level memory out of several related rows via the
+ * merge op. It can never invent memories from nothing: every merge must cite
+ * source rows, which become superseded by the synthesis.
+ */
+export async function consolidateMemories(userId: number): Promise<void> {
+  if (!process.env.ANTHROPIC_API_KEY) return;
+
+  const active = await db
+    .select({
+      id: memories.id,
+      kind: memories.kind,
+      body: memories.body,
+      pinned: memories.pinned,
+    })
+    .from(memories)
+    .where(
+      and(
+        eq(memories.user_id, userId),
+        isNull(memories.superseded_by),
+        isNull(memories.evicted_at),
+      ),
+    )
+    .orderBy(desc(memories.updated_at));
+  if (active.length < 2) return;
+
+  const list = active
+    .map((m) => `  ${m.id} [${m.kind}]${m.pinned ? " [pinned]" : ""} ${m.body}`)
+    .join("\n");
+
+  const prompt = `You are a memory janitor for a conversational AI. Below is the FULL list of stored memories for one user. Your job is consolidation: merge duplicates, remove stale entries, tighten wording, and distill patterns. Default is to change NOTHING.
+
+Each operation is one of:
+  { "op": "supersede", "id": <memory id>, "body": "<replacement, one or two sentences>" }
+  { "op": "delete", "id": <memory id> }
+  { "op": "merge", "ids": [<two or more memory ids>], "kind": "preference" | "fact" | "decision" | "open_thread" | "entity", "body": "<one or two sentences>" }
+
+Apply ops ONLY for:
+- Duplicates/paraphrases of the same underlying fact: merge them — cite all duplicate ids, keep the best phrasing, fold in any unique detail.
+- Completed or abandoned open threads — one-off progress notes with no future value: delete.
+- Bodies anchored to stale context ("currently", "this week", a clearly-finished task): supersede with a timeless phrasing, or delete if nothing timeless remains.
+- Reflection: several related rows that together show a durable pattern (e.g. multiple completed threads about the same ongoing project or interest) may merge into ONE higher-level memory stating that pattern. The merged kind may differ from the sources (e.g. open_threads distill into a fact).
+
+Rules:
+- NEVER invent memories. Every merge must cite only ids listed below, and its body must be fully supported by the cited rows — no embellishment, no inference beyond what is written.
+- Do not delete [pinned] rows unless they duplicate another row.
+- Reflection merges should be rare and obviously right. When in doubt, leave rows alone.
+- If the list is healthy, return [].
+
+Memories:
+${list}
+
+Return ONLY a JSON array of operations, no commentary or markdown.`;
+
+  let ops: ExtractorOp[];
+  try {
+    const model = getAnthropicModel(EXTRACTOR_MODEL);
+    const result = await generateText({ model, prompt, temperature: 0.2 });
+    const parsed = parseOpsJson(result.text);
+    if (!parsed) {
+      console.warn("[memory] janitor returned non-array, skipping");
+      return;
+    }
+    ops = parsed;
+  } catch (err) {
+    console.error("[memory] janitor call/parse failed:", err);
+    return;
+  }
+
+  let applied = 0;
+  for (const op of ops) {
+    try {
+      if (op.op === "supersede" && op.id && op.body) {
+        await supersedeMemory(op.id, op.body, { userId });
+        applied++;
+      } else if (op.op === "delete" && op.id) {
+        await deleteMemory(op.id, userId);
+        applied++;
+      } else if (op.op === "merge" && op.kind && op.body && (op.ids?.length ?? 0) >= 2) {
+        const created = await mergeMemories({
+          userId,
+          kind: op.kind,
+          body: op.body,
+          sourceIds: op.ids!,
+        });
+        if (created) applied++;
+      }
+      // Bare "create" and anything else is deliberately ignored.
+    } catch (err) {
+      console.error("[memory] failed to apply janitor op:", op, err);
+    }
+  }
+
+  if (applied > 0) {
+    console.log(`[memory] janitor applied ${applied} op(s) for user ${userId}`);
   }
 }

--- a/server/tools/manual/forget-memory.ts
+++ b/server/tools/manual/forget-memory.ts
@@ -1,0 +1,88 @@
+import type { Tool } from './types';
+import { deleteMemory, findMemoriesByQuery } from '../../memory-service';
+
+// Delete without confirmation only above this similarity; below it, return
+// candidates and require a second call with memory_id.
+const CONFIDENT_DELETE_SIMILARITY = 0.7;
+
+/**
+ * Explicit, synchronous forget. Complement of save_memory: "forget X" acts
+ * immediately (hard delete — explicit user intent, unlike decay's soft
+ * invalidation) instead of waiting for the background extractor.
+ */
+export const forgetMemoryTool: Tool = {
+  name: 'forget_memory',
+  description:
+    'Delete stored persistent memories about the user. Use when the user asks you to forget or stop remembering ' +
+    'something ("forget that...", "stop bringing up..."). Pass a description of what to forget; clearly matching ' +
+    'memories are deleted immediately, ambiguous matches are returned as candidates — confirm the right one by ' +
+    'calling again with its memory_id. Deletion is permanent.',
+  parameters: {
+    type: 'object',
+    properties: {
+      query: {
+        type: 'string',
+        description: 'What to forget, described in natural language (e.g. "my favorite color").',
+      },
+      memory_id: {
+        type: 'number',
+        description: 'Exact memory id to delete — use after a previous call returned candidates.',
+      },
+    },
+    required: [],
+  },
+  execute: async (
+    params: { query?: string; memory_id?: number },
+    ctx?: { userId?: number },
+  ) => {
+    try {
+      if (!ctx?.userId) {
+        return { success: false, error: 'forget_memory requires user context.' };
+      }
+      const userId = ctx.userId;
+
+      if (params.memory_id != null) {
+        // deleteMemory is user-scoped: a wrong id belonging to someone else is a no-op.
+        await deleteMemory(params.memory_id, userId);
+        return { success: true, deleted_memory_id: params.memory_id };
+      }
+
+      const query = params.query?.trim();
+      if (!query) {
+        return { success: false, error: 'Provide query or memory_id.' };
+      }
+
+      const matches = await findMemoriesByQuery(userId, query, { limit: 5, minSimilarity: 0.5 });
+      if (matches.length === 0) {
+        return { success: true, deleted: [], note: 'No stored memories match that description.' };
+      }
+
+      const confident = matches.filter((m) => m.similarity >= CONFIDENT_DELETE_SIMILARITY);
+      if (confident.length > 0) {
+        for (const m of confident) {
+          await deleteMemory(m.row.id, userId);
+        }
+        return {
+          success: true,
+          deleted: confident.map((m) => ({ memory_id: m.row.id, body: m.row.body })),
+        };
+      }
+
+      return {
+        success: true,
+        deleted: [],
+        candidates: matches.map((m) => ({
+          memory_id: m.row.id,
+          body: m.row.body,
+          similarity: Number(m.similarity.toFixed(2)),
+        })),
+        note: 'No confident match. If one of these is what the user means, call forget_memory again with its memory_id.',
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  },
+};

--- a/server/tools/manual/index.ts
+++ b/server/tools/manual/index.ts
@@ -13,6 +13,8 @@ import { screenshotTool } from './screenshot';
 import { createCustomToolTool } from './create-custom-tool';
 import { generateUITool } from './generate-ui';
 import { searchPastConversationsTool } from './search-past-conversations';
+import { saveMemoryTool } from './save-memory';
+import { forgetMemoryTool } from './forget-memory';
 
 export const manualTools = [
   calculatorTool,
@@ -31,4 +33,6 @@ export const manualTools = [
   createCustomToolTool,
   generateUITool,
   searchPastConversationsTool,
+  saveMemoryTool,
+  forgetMemoryTool,
 ];

--- a/server/tools/manual/save-memory.ts
+++ b/server/tools/manual/save-memory.ts
@@ -1,0 +1,80 @@
+import type { Tool } from './types';
+import { createMemory } from '../../memory-service';
+
+/**
+ * Explicit, synchronous save into hot-tier memory. The background extractor
+ * remains the passive path; this tool exists so "remember that ..." takes
+ * effect immediately and certainly instead of hoping the extractor catches it.
+ */
+export const saveMemoryTool: Tool = {
+  name: 'save_memory',
+  description:
+    'Save a fact about the user to persistent cross-conversation memory, effective immediately. ' +
+    'Use ONLY when the user explicitly asks you to remember something ("remember that...", "note for the future...") ' +
+    'or states a clearly durable preference/correction that should apply to future conversations. ' +
+    'Do not use for ephemeral task state or general knowledge. Near-duplicates of an existing memory are ' +
+    'automatically folded into it.',
+  parameters: {
+    type: 'object',
+    properties: {
+      kind: {
+        type: 'string',
+        enum: ['preference', 'fact', 'decision', 'open_thread', 'entity'],
+        description:
+          'preference = how the user wants things done; fact = stable info about the user/their world; ' +
+          'decision = a choice they made; open_thread = ongoing work to follow up on; entity = a person/project/thing they reference.',
+      },
+      body: {
+        type: 'string',
+        description:
+          'The memory, one or two self-contained sentences. Name the subject explicitly — a future reader has no surrounding conversation.',
+      },
+      pinned: {
+        type: 'boolean',
+        description:
+          'true ONLY for facts that should influence EVERY future conversation regardless of topic (identity, hard rules, global style). Default false.',
+      },
+    },
+    required: ['kind', 'body'],
+  },
+  execute: async (
+    params: {
+      kind: 'preference' | 'fact' | 'decision' | 'open_thread' | 'entity';
+      body: string;
+      pinned?: boolean;
+    },
+    ctx?: { userId?: number },
+  ) => {
+    try {
+      if (!ctx?.userId) {
+        return { success: false, error: 'save_memory requires user context.' };
+      }
+      const body = params.body?.trim();
+      if (!body) {
+        return { success: false, error: 'body must be a non-empty string.' };
+      }
+      // Explicit user request = direct statement: high confidence.
+      const row = await createMemory({
+        userId: ctx.userId,
+        kind: params.kind,
+        body,
+        confidence: 95,
+        pinned: params.pinned === true,
+      });
+      return {
+        success: true,
+        memory_id: row.id,
+        saved: row.body,
+        note:
+          row.body === body
+            ? 'Saved.'
+            : 'An equivalent memory already existed; it was reinforced/updated instead of duplicated.',
+      };
+    } catch (error) {
+      return {
+        success: false,
+        error: error instanceof Error ? error.message : 'Unknown error',
+      };
+    }
+  },
+};


### PR DESCRIPTION
## Summary
Reworks the persistent cross-conversation memory system so information falls off instead of accumulating forever. Design is grounded in prior art: Stanford generative agents (additive scoring, reflection), Mem0 (similarity-ranked routing context, non-destructive decay), Zep/Graphiti (invalidation over deletion), and FSRS/ACT-R (spaced-repetition stability growth).

- **Decay**: per-kind half-lives (open_thread 14d → preference 365d); below 0.15 effective strength a memory is invisible and invalidated (`evicted_at`), not deleted; hard purge only after 180d evicted / 30d superseded. Tombstone log on every eviction.
- **FSRS-style stability**: reinforcement grows the half-life multiplier by `1 + 1.5·(1−retrievability)` (cap 64×) — repeatedly-confirmed facts become effectively permanent without pinning.
- **Rich-get-richer loop fixed**: always-on injection is pinned-only and no longer self-reinforces via `use_count`.
- **Mechanical dedup at create** (same-kind cosine): ≥0.95 reinforces, 0.88–0.95 supersedes; evicted matches are resurrected.
- **Extractor**: sees pinned + recent + similarity-ranked memories, gains a `reinforce` op.
- **Janitor** (every 10th extraction or >60 active): merges paraphrase dupes, prunes stale threads, and may synthesize a higher-level memory from ≥2 cited sources (reflection); creates from nothing forbidden.
- **New in-chat tools**: `save_memory` / `forget_memory` for explicit synchronous remember/forget.
- Migration 0010 backfills legacy rows idempotently (strength from confidence, reinforcement clock from `updated_at`).

## Test plan
- [x] `docker compose build` + in-container `tsc` clean for all touched files
- [x] Migration applies on boot; legacy rows backfilled correctly (verified via psql)
- [x] Eviction predicate verified in rolled-back SQL: 250-day-old fact with stability 1 evicts, stability 4 survives
- [x] App boots and serves
- [ ] Live-chat behaviors (reinforce op, tools, resurrection, reflection merges) — observe `[memory]` log lines over normal use

🤖 Generated with [Claude Code](https://claude.com/claude-code)