### PR TITLE
Hotfix: server crash guards + sharp pin for pre-v2 CPUs

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,6 +15,9 @@
     "test:agentic": "bash test-agentic.sh",
     "test:agentic:local": "node test-agentic-mode.mjs"
   },
+  "overrides": {
+    "sharp": "0.33.5"
+  },
   "dependencies": {
     "@ai-sdk/anthropic": "^3.0.0",
     "@ai-sdk/google": "^3.0.0",

--- a/server/index.ts
+++ b/server/index.ts
@@ -5,6 +5,16 @@ import https from "https";
 import { registerRoutes } from "./routes";
 import { setupVite, serveStatic, log } from "./vite";
 
+// Last-resort safety nets: a background failure (PII classifier load, a
+// fire-and-forget task, a provider SDK edge case) must never take down the
+// whole server. Log loudly and keep serving.
+process.on("unhandledRejection", (reason) => {
+  console.error("[fatal-guard] unhandled promise rejection:", reason);
+});
+process.on("uncaughtException", (err) => {
+  console.error("[fatal-guard] uncaught exception:", err);
+});
+
 const app = express();
 
 // Serve uploaded files
@@ -81,8 +91,10 @@ app.use((req, res, next) => {
     const status = err.status || err.statusCode || 500;
     const message = err.message || "Internal Server Error";
 
-    res.status(status).json({ message });
-    throw err;
+    console.error("[express] request failed:", err);
+    if (!res.headersSent) {
+      res.status(status).json({ message });
+    }
   });
 
   // importantly only setup vite in development and after


### PR DESCRIPTION
## Summary

Two fixes that missed the #25 merge window:

- **Never crash the whole server**: the global Express error middleware rethrew after responding (process-killer); replaced with log + guarded response. Added process-level `unhandledRejection`/`uncaughtException` guards that log and keep serving.
- **Pin sharp to 0.33.5** (npm overrides): sharp 0.34+ prebuilt binaries require x86-64-v2 and fail to load on older CPUs/VMs, killing the PII NER classifier at startup. Same no-lockfile drift class as the earlier react-icons pin.

🤖 Generated with [Claude Code](https://claude.com/claude-code)