### PR TITLE
feat: OpenRouter agentic mode, AI SDK v7 migration

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,3 @@
+# Shell scripts must keep LF endings — they run inside Linux containers,
+# and a CRLF shebang breaks exec (autocrlf=true checkouts on Windows).
+*.sh text eol=lf

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM node:20-slim AS builder
+FROM node:22-slim AS builder
 
 WORKDIR /app
 
@@ -22,7 +22,7 @@ RUN npm run build
 RUN mkdir -p dist/providers && cp -r server/config/providers/* dist/providers/
 
 # Production stage
-FROM node:20-slim
+FROM node:22-slim
 
 WORKDIR /app
 

--- a/Dockerfile.test
+++ b/Dockerfile.test
@@ -1,5 +1,5 @@
 # Test container for running agentic mode integration tests
-FROM node:20-slim
+FROM node:22-slim
 
 WORKDIR /test
 

--- a/package.json
+++ b/package.json
@@ -19,10 +19,10 @@
     "sharp": "0.33.5"
   },
   "dependencies": {
-    "@ai-sdk/anthropic": "^3.0.0",
-    "@ai-sdk/google": "^3.0.0",
-    "@ai-sdk/openai": "^3.0.0",
-    "@ai-sdk/xai": "^3.0.0",
+    "@ai-sdk/anthropic": "^4.0.0",
+    "@ai-sdk/google": "^4.0.0",
+    "@ai-sdk/openai": "^4.0.0",
+    "@ai-sdk/xai": "^4.0.0",
     "@anthropic-ai/sdk": "^0.33.1",
     "@dnd-kit/core": "^6.3.1",
     "@dnd-kit/sortable": "^10.0.0",
@@ -30,7 +30,7 @@
     "@fal-ai/client": "^1.3.0",
     "@google/generative-ai": "^0.24.0",
     "@huggingface/transformers": "^3.5.0",
-    "ai": "^6.0.0",
+    "ai": "^7.0.0",
     "@hookform/resolvers": "^3.9.1",
     "@jridgewell/trace-mapping": "^0.3.25",
     "@modelcontextprotocol/sdk": "^1.17.4",

--- a/server/agentic-workflow.ts
+++ b/server/agentic-workflow.ts
@@ -1,4 +1,4 @@
-import { ToolLoopAgent, stepCountIs, tool, LanguageModel } from "ai";
+import { ToolLoopAgent, isStepCount, tool, LanguageModel } from "ai";
 import { z, ZodTypeAny, ZodObject, ZodRawShape } from "zod";
 import { getToolDefinitions, executeTool, refreshTools } from "./tools";
 import { db } from "@db";
@@ -79,7 +79,7 @@ function jsonSchemaPropertyToZod(prop: any): ZodTypeAny {
 
 /**
  * Convert a JSON Schema object to a Zod schema
- * This converts our tool parameter definitions to Zod schemas for AI SDK v6
+ * This converts our tool parameter definitions to Zod schemas for AI SDK v7
  */
 function jsonSchemaToZod(schema: any): ZodObject<ZodRawShape> {
   const shape: ZodRawShape = {};
@@ -101,7 +101,7 @@ function jsonSchemaToZod(schema: any): ZodObject<ZodRawShape> {
 }
 
 /**
- * Convert our tool definitions to AI SDK v6 tool format
+ * Convert our tool definitions to AI SDK v7 tool format
  * This function dynamically loads tools, supporting hot reload of custom tools
  */
 async function buildAgentTools(forceReload: boolean = false, userId?: number): Promise<Record<string, any>> {
@@ -117,11 +117,11 @@ async function buildAgentTools(forceReload: boolean = false, userId?: number): P
     const func = toolDef.function;
     
     // Convert JSON Schema parameters to Zod schema
-    // AI SDK v6 works best with Zod schemas
+    // AI SDK v7 works best with Zod schemas
     const zodSchema = jsonSchemaToZod(func.parameters);
     
-    // Use AI SDK v6 tool() helper with Zod schema
-    // Note: AI SDK v6 uses 'inputSchema' instead of 'parameters'
+    // Use AI SDK v7 tool() helper with Zod schema
+    // Note: AI SDK v7 uses 'inputSchema' instead of 'parameters'
     tools[func.name] = tool({
       description: func.description,
       inputSchema: zodSchema,
@@ -166,7 +166,7 @@ async function buildAgentTools(forceReload: boolean = false, userId?: number): P
 
 /**
  * Create a ToolLoopAgent instance for agentic workflows
- * This leverages the new AI SDK v6 Agent class for cleaner, more maintainable code
+ * This leverages the new AI SDK v7 Agent class for cleaner, more maintainable code
  */
 export async function createAgenticAgent(config: {
   model: LanguageModel;
@@ -185,14 +185,14 @@ export async function createAgenticAgent(config: {
     model,
     instructions: systemPrompt,
     tools,
-    stopWhen: stepCountIs(maxIterations),
+    stopWhen: isStepCount(maxIterations),
   });
 
   return agent;
 }
 
 /**
- * Run the agentic workflow using AI SDK v6 ToolLoopAgent
+ * Run the agentic workflow using AI SDK v7 ToolLoopAgent
  * This function works with ALL AI SDK supported providers:
  * - OpenAI (GPT-4, GPT-4o, GPT-5, o1, o3, etc.)
  * - Anthropic (Claude 3.5 Sonnet, Claude 3 Opus, etc.)
@@ -237,12 +237,12 @@ export async function runAgenticLoop(
     model,
     instructions: redactedSystemPrompt,
     tools,
-    stopWhen: stepCountIs(maxIterations),
+    stopWhen: isStepCount(maxIterations),
   });
 
   try {
     // Build the prompt from initial messages
-    // AI SDK v6 ToolLoopAgent doesn't allow both prompt and messages at the same time
+    // AI SDK v7 ToolLoopAgent doesn't allow both prompt and messages at the same time
     // So we use prompt for new conversations, and messages for conversations with history
     const lastUserMessage = redactedMessages.filter(m => m.role === 'user').pop();
     const prompt = lastUserMessage?.content || '';
@@ -290,7 +290,7 @@ export async function runAgenticLoop(
             content: JSON.stringify(await restoreDeep(step.toolCalls.map(tc => ({
               id: tc.toolCallId,
               name: tc.toolName,
-              arguments: tc.args
+              arguments: tc.input
             })))),
             metadata: {
               type: 'agentic_tool_calls',

--- a/server/ai-sdk-providers.ts
+++ b/server/ai-sdk-providers.ts
@@ -15,7 +15,6 @@ import type { LanguageModel } from 'ai';
 export function getOpenAIModel(modelName: string, apiKey?: string): LanguageModel {
   const openai = createOpenAI({
     apiKey: apiKey || process.env.OPENAI_API_KEY,
-    compatibility: 'strict', // Ensure full compatibility
   });
   
   return openai(modelName);
@@ -63,8 +62,9 @@ export function getDeepSeekModel(modelName: string, apiKey?: string): LanguageMo
     apiKey: apiKey || process.env.DEEPSEEK_API_KEY,
     baseURL: 'https://api.deepseek.com/v1',
   });
-  
-  return deepseek(modelName);
+
+  // Use .chat() to force Chat Completions API — DeepSeek doesn't support the OpenAI Responses API
+  return deepseek.chat(modelName);
 }
 
 /**
@@ -76,8 +76,9 @@ export function getGroqModel(modelName: string, apiKey?: string): LanguageModel 
     apiKey: apiKey || process.env.GROQ_API_KEY,
     baseURL: 'https://api.groq.com/openai/v1',
   });
-  
-  return groq(modelName);
+
+  // Use .chat() to force Chat Completions API — Groq doesn't support the OpenAI Responses API
+  return groq.chat(modelName);
 }
 
 /**
@@ -107,6 +108,24 @@ export function getOllamaModel(modelName: string): LanguageModel {
 }
 
 /**
+ * Get an AI SDK model instance for OpenRouter
+ * OpenRouter is OpenAI-compatible, uses custom baseURL and attribution headers
+ */
+export function getOpenRouterModel(modelName: string, apiKey?: string): LanguageModel {
+  const openrouter = createOpenAI({
+    apiKey: apiKey || process.env.OPENROUTER_API_KEY,
+    baseURL: 'https://openrouter.ai/api/v1',
+    headers: {
+      'HTTP-Referer': process.env.PROXY_DOMAIN ? `https://${process.env.PROXY_DOMAIN}` : 'http://localhost:5000',
+      'X-Title': process.env.NEXT_PUBLIC_CUSTOMER_NAME || 'LLM UI',
+    },
+  });
+
+  // Use .chat() to force Chat Completions API — OpenRouter doesn't support the OpenAI Responses API
+  return openrouter.chat(modelName);
+}
+
+/**
  * Get an AI SDK model instance for any OpenAI-compatible provider
  */
 export function getOpenAICompatibleModel(
@@ -118,8 +137,9 @@ export function getOpenAICompatibleModel(
     apiKey,
     baseURL,
   });
-  
-  return provider(modelName);
+
+  // Use .chat() to force Chat Completions API — compatible providers rarely serve the Responses API
+  return provider.chat(modelName);
 }
 
 /**

--- a/server/routes/providers/anthropic.ts
+++ b/server/routes/providers/anthropic.ts
@@ -561,7 +561,7 @@ router.post("/", async (req: Request, res: Response) => {
         // Convert messages to simple format for agent - use contextManagedMessages which has been truncated
         const agentMessages = convertToAgentMessages(contextManagedMessages);
         
-        // Run the agentic loop with AI SDK v6 ToolLoopAgent
+        // Run the agentic loop with AI SDK v7 ToolLoopAgent
         const finalResponse = await runAgenticLoop(
           agentMessages,
           {

--- a/server/routes/providers/gemini.ts
+++ b/server/routes/providers/gemini.ts
@@ -412,7 +412,7 @@ router.post("/", async (req: Request, res: Response) => {
         // Convert to simple format for agent
         const agentMessages = convertToAgentMessages(agentApiMessages);
 
-        // Run the agentic loop with AI SDK v6 ToolLoopAgent
+        // Run the agentic loop with AI SDK v7 ToolLoopAgent
         const finalResponse = await runAgenticLoop(
           agentMessages,
           {

--- a/server/routes/providers/ollama.ts
+++ b/server/routes/providers/ollama.ts
@@ -406,7 +406,7 @@ router.post("/", async (req: Request, res: Response) => {
         // Convert messages to simple format for agent
         const agentMessages = convertToAgentMessages(contextManagedMessages);
 
-        // Run the agentic loop with AI SDK v6 ToolLoopAgent
+        // Run the agentic loop with AI SDK v7 ToolLoopAgent
         const finalResponse = await runAgenticLoop(
           agentMessages,
           {

--- a/server/routes/providers/ollama.ts
+++ b/server/routes/providers/ollama.ts
@@ -306,8 +306,12 @@ router.post("/", async (req: Request, res: Response) => {
       }
     );
 
+    // Agentic mode makes its own requests through the AI SDK loop — skip the
+    // direct completion stream entirely.
+    const isAgentic = useAgenticMode && useTools;
+
     // Stream the completion with retries
-    while (retryCount < maxRetries) {
+    while (!isAgentic && retryCount < maxRetries) {
       try {
         const streamOptions: any = {
           messages: contextManagedMessages,
@@ -367,7 +371,7 @@ router.post("/", async (req: Request, res: Response) => {
       }
     }
 
-    if (!stream) {
+    if (!stream && !isAgentic) {
       throw new Error("Failed to create stream after retries");
     }
 
@@ -393,7 +397,7 @@ router.post("/", async (req: Request, res: Response) => {
       const requestStart = Date.now();
 
       // Check if using agentic mode
-      if (useAgenticMode && useTools) {
+      if (isAgentic) {
         console.log('[Ollama] Using agentic mode with AI SDK');
 
         // Get the AI SDK model instance for Ollama
@@ -454,7 +458,7 @@ router.post("/", async (req: Request, res: Response) => {
         // across chunk boundaries.
         const piiRestorer = createStreamRestorer();
 
-        for await (const chunk of stream) {
+        for await (const chunk of stream!) {
           const content = chunk.choices[0]?.delta?.content || "";
           const toolCallsDelta = chunk.choices[0]?.delta?.tool_calls;
 

--- a/server/routes/providers/openai.ts
+++ b/server/routes/providers/openai.ts
@@ -662,8 +662,12 @@ router.post("/", async (req: Request, res: Response) => {
       })}\n\n`);
     }
 
+    // Agentic mode makes its own requests through the AI SDK loop — skip the
+    // direct completion stream entirely.
+    const isAgentic = useAgenticMode && useTools;
+
     // Stream the completion with retries
-    while (retryCount < maxRetries) {
+    while (!isAgentic && retryCount < maxRetries) {
       try {
         // Reasoning models (o-series, GPT-5 family) reject custom temperature —
         // omit the param entirely for them. Older chat models (gpt-4o, gpt-4.1,
@@ -736,7 +740,7 @@ router.post("/", async (req: Request, res: Response) => {
       }
     }
 
-    if (!stream) {
+    if (!stream && !isAgentic) {
       throw new Error("Failed to create stream after retries");
     }
 
@@ -754,7 +758,7 @@ router.post("/", async (req: Request, res: Response) => {
       const requestStart = Date.now();
       
       // Check if using agentic mode
-      if (useAgenticMode && useTools) {
+      if (isAgentic) {
         console.log('[OpenAI] Using agentic mode with AI SDK');
         
         // Get the AI SDK model instance

--- a/server/routes/providers/openai.ts
+++ b/server/routes/providers/openai.ts
@@ -767,7 +767,7 @@ router.post("/", async (req: Request, res: Response) => {
         // Convert messages to simple format for agent - use contextManagedMessages which has been truncated
         const agentMessages = convertToAgentMessages(contextManagedMessages);
         
-        // Run the agentic loop with AI SDK v6 ToolLoopAgent
+        // Run the agentic loop with AI SDK v7 ToolLoopAgent
         const finalResponse = await runAgenticLoop(
           agentMessages,
           {

--- a/server/routes/providers/openrouter.ts
+++ b/server/routes/providers/openrouter.ts
@@ -8,6 +8,8 @@ import { eq } from "drizzle-orm";
 import { transformDatabaseConversation } from "@/lib/llm/types";
 import { prepareKnowledgeContentForConversation, addKnowledgeToConversation } from "../../knowledge-service";
 import { prepareContext, isContextLengthError } from "../../context-manager";
+import { runAgenticLoop } from "../../agentic-workflow";
+import { getOpenRouterModel } from "../../ai-sdk-providers";
 import { buildSystemPrompt } from "../../user-preferences-service";
 import { scheduleExtraction } from "../../memory-service";
 import { redactDeep, restoreText, createStreamRestorer, schedulePiiClassification } from "../../pii-service";
@@ -37,6 +39,16 @@ export function getOpenRouterClient() {
   return client;
 }
 
+// Helper to convert OpenRouter messages to simple format for agent
+function convertToAgentMessages(messages: any[]): Array<{ role: 'user' | 'assistant'; content: string }> {
+  return messages
+    .filter(msg => msg.role === 'user' || msg.role === 'assistant')
+    .map(msg => ({
+      role: msg.role as 'user' | 'assistant',
+      content: typeof msg.content === 'string' ? msg.content : JSON.stringify(msg.content)
+    }));
+}
+
 // Create or continue an OpenRouter chat conversation
 router.post("/", async (req: Request, res: Response) => {
   try {
@@ -50,6 +62,8 @@ router.post("/", async (req: Request, res: Response) => {
       allAttachments = [],
       useKnowledge = false,
       pendingKnowledgeSources = [],
+      useTools = false,
+      useAgenticMode = false,
       skipSystemPrompt = false,
     } = req.body;
 
@@ -295,14 +309,18 @@ router.post("/", async (req: Request, res: Response) => {
       model,
       {
         maxTokens: modelContextLength, // Use context length from model config
-        reserveForTools: 0,
+        reserveForTools: useTools ? 8000 : 0, // Only reserve for tools if enabled
       }
     );
+
+    // Agentic mode makes its own requests through the AI SDK loop — skip the
+    // direct completion stream entirely.
+    const isAgentic = useAgenticMode && useTools;
 
     // Stream the completion with retries.
     // No temperature: OpenRouter routes to hundreds of models and several
     // (reasoning models, GPT-5 family, Kimi K3) reject custom values.
-    while (retryCount < maxRetries) {
+    while (!isAgentic && retryCount < maxRetries) {
       try {
         // Redacted: known PII entities and freshly detected PII are replaced
         // with tags before leaving the machine (re-redacts on each retry).
@@ -345,7 +363,7 @@ router.post("/", async (req: Request, res: Response) => {
       }
     }
 
-    if (!stream) {
+    if (!stream && !isAgentic) {
       throw new Error("Failed to create stream after retries");
     }
 
@@ -370,76 +388,129 @@ router.post("/", async (req: Request, res: Response) => {
 
     try {
       const requestStart = Date.now();
-      let ttftMs: number | null = null;
-      let lastChunkTime = Date.now();
-      // Reasoning models (e.g. Kimi K3 with always-on thinking) can pause for a
-      // while before the first visible token — use a generous chunk timeout.
-      const chunkTimeout = 120000;
-      // Restores PII tags in streamed text; buffers tag fragments split
-      // across chunk boundaries.
-      const piiRestorer = createStreamRestorer();
 
-      for await (const chunk of stream) {
-        const content = chunk.choices[0]?.delta?.content || "";
-        if (content) {
-          streamedResponse += content;
-          lastChunkTime = Date.now();
-          if (ttftMs === null) {
-            ttftMs = lastChunkTime - requestStart;
+      // Check if using agentic mode
+      if (isAgentic) {
+        console.log('[OpenRouter] Using agentic mode with AI SDK');
+
+        // Get the AI SDK model instance
+        const aiModel = getOpenRouterModel(model);
+
+        // Extract system prompt from contextManagedMessages (which has been truncated if needed)
+        const systemMessage = contextManagedMessages.find((msg: any) => msg.role === 'system');
+        const systemPrompt = systemMessage?.content || undefined;
+
+        // Convert messages to simple format for agent - use contextManagedMessages which has been truncated
+        const agentMessages = convertToAgentMessages(contextManagedMessages);
+
+        // Run the agentic loop with AI SDK v7 ToolLoopAgent
+        const finalResponse = await runAgenticLoop(
+          agentMessages,
+          {
+            maxIterations: 20,
+            conversationId: dbConversation.id,
+            model: aiModel,
+            systemPrompt,
+            userId: req.user!.id
           }
-          const restored = await piiRestorer.push(content);
-          if (restored) {
-            res.write(
-              `data: ${JSON.stringify({ type: "chunk", content: restored })}\n\n`,
-            );
+        );
+
+        // Stream the final response to the user
+        if (finalResponse) {
+          const chunkSize = 50;
+          for (let i = 0; i < finalResponse.length; i += chunkSize) {
+            const chunk = finalResponse.slice(i, i + chunkSize);
+            res.write(`data: ${JSON.stringify({ type: "chunk", content: chunk })}\n\n`);
+            await new Promise(resolve => setTimeout(resolve, 20));
           }
+
+          streamedResponse = finalResponse;
+
+          // Save the final response
+          await db.insert(messages).values({
+            conversation_id: dbConversation.id,
+            role: "assistant",
+            content: finalResponse,
+            metadata: {
+              agentic_mode: true,
+              ai_sdk: true,
+              ttft_ms: Date.now() - requestStart
+            },
+            created_at: new Date(),
+          });
+        }
+      } else {
+        let ttftMs: number | null = null;
+        let lastChunkTime = Date.now();
+        // Reasoning models (e.g. Kimi K3 with always-on thinking) can pause for a
+        // while before the first visible token — use a generous chunk timeout.
+        const chunkTimeout = 120000;
+        // Restores PII tags in streamed text; buffers tag fragments split
+        // across chunk boundaries.
+        const piiRestorer = createStreamRestorer();
+
+        for await (const chunk of stream!) {
+          const content = chunk.choices[0]?.delta?.content || "";
+          if (content) {
+            streamedResponse += content;
+            lastChunkTime = Date.now();
+            if (ttftMs === null) {
+              ttftMs = lastChunkTime - requestStart;
+            }
+            const restored = await piiRestorer.push(content);
+            if (restored) {
+              res.write(
+                `data: ${JSON.stringify({ type: "chunk", content: restored })}\n\n`,
+              );
+            }
+            (res as any).flush?.();
+          }
+
+          // Check for timeout between chunks
+          if (Date.now() - lastChunkTime > chunkTimeout) {
+            throw new Error("Stream timeout - no data received for 120 seconds");
+          }
+        }
+
+        // Emit any held-back tag fragment and convert accumulated tags back to
+        // real values before persisting (DB keeps real values).
+        const piiTail = await piiRestorer.flush();
+        if (piiTail) {
+          res.write(`data: ${JSON.stringify({ type: "chunk", content: piiTail })}\n\n`);
           (res as any).flush?.();
         }
+        streamedResponse = await restoreText(streamedResponse);
 
-        // Check for timeout between chunks
-        if (Date.now() - lastChunkTime > chunkTimeout) {
-          throw new Error("Stream timeout - no data received for 120 seconds");
-        }
+        // Save the complete response only after successful streaming
+        const timestamp = new Date();
+        // Approximate input tokens from apiMessages
+        let approxInputTokens = 0;
+        try {
+          const texts: string[] = [];
+          for (const m of apiMessages as any[]) {
+            if (typeof m?.content === 'string') texts.push(m.content);
+          }
+          const EULER = 2.7182818284590;
+          const combined = texts.join('\n');
+          if (combined) {
+            const len = combined.length;
+            approxInputTokens = Math.ceil(len / EULER) + (len > 2000 ? 8 : 2);
+          }
+        } catch {}
+        await db.insert(messages).values({
+          conversation_id: dbConversation.id,
+          role: "assistant",
+          content: streamedResponse,
+          metadata: {
+            ttft_ms: ttftMs ?? undefined,
+            total_tokens: (stream as any)?.response?.usage?.total_tokens,
+            input_tokens: (stream as any)?.response?.usage?.prompt_tokens ?? (stream as any)?.response?.usage?.input_tokens,
+            output_tokens: (stream as any)?.response?.usage?.completion_tokens ?? (stream as any)?.response?.usage?.output_tokens,
+            approx_input_tokens: approxInputTokens,
+          },
+          created_at: timestamp,
+        });
       }
-
-      // Emit any held-back tag fragment and convert accumulated tags back to
-      // real values before persisting (DB keeps real values).
-      const piiTail = await piiRestorer.flush();
-      if (piiTail) {
-        res.write(`data: ${JSON.stringify({ type: "chunk", content: piiTail })}\n\n`);
-        (res as any).flush?.();
-      }
-      streamedResponse = await restoreText(streamedResponse);
-
-      // Save the complete response only after successful streaming
-      const timestamp = new Date();
-      // Approximate input tokens from apiMessages
-      let approxInputTokens = 0;
-      try {
-        const texts: string[] = [];
-        for (const m of apiMessages as any[]) {
-          if (typeof m?.content === 'string') texts.push(m.content);
-        }
-        const EULER = 2.7182818284590;
-        const combined = texts.join('\n');
-        if (combined) {
-          const len = combined.length;
-          approxInputTokens = Math.ceil(len / EULER) + (len > 2000 ? 8 : 2);
-        }
-      } catch {}
-      await db.insert(messages).values({
-        conversation_id: dbConversation.id,
-        role: "assistant",
-        content: streamedResponse,
-        metadata: {
-          ttft_ms: ttftMs ?? undefined,
-          total_tokens: (stream as any)?.response?.usage?.total_tokens,
-          input_tokens: (stream as any)?.response?.usage?.prompt_tokens ?? (stream as any)?.response?.usage?.input_tokens,
-          output_tokens: (stream as any)?.response?.usage?.completion_tokens ?? (stream as any)?.response?.usage?.output_tokens,
-          approx_input_tokens: approxInputTokens,
-        },
-        created_at: timestamp,
-      });
 
       // Send completion event after successful save
       const updatedConversation = await db.query.conversations.findFirst({

--- a/test-agentic-mode.mjs
+++ b/test-agentic-mode.mjs
@@ -341,6 +341,12 @@ async function main() {
         envVar: 'ANTHROPIC_API_KEY'
       },
       {
+        name: 'OpenRouter',
+        model: 'moonshotai/kimi-k3',
+        endpoint: '/api/chat/openrouter',
+        envVar: 'OPENROUTER_API_KEY'
+      },
+      {
         name: 'Google Gemini',
         model: 'gemini-pro',
         endpoint: '/api/chat/gemini',


### PR DESCRIPTION
## Summary
Promotes dev to main. Contains PR #27:

- **OpenRouter agentic/tool access** via the shared `runAgenticLoop` (new `getOpenRouterModel()` factory, `.chat()` forced since OpenRouter has no OpenAI Responses API)
- **AI SDK v6 → v7, @ai-sdk/* v3 → v4**: `stepCountIs` → `isStepCount`; `toolCalls[].args` → `.input` (fixes agentic tool-call arguments persisting as `undefined`); Node 20 → 22 in Docker images (v7 requirement)
- **DeepSeek/Groq/generic-compatible factories** switched to `.chat()` (same latent Responses-API bug)
- **Efficiency fix**: openai.ts and ollama.ts no longer open a throwaway completion stream in agentic mode (previously billed one full unread completion per agentic request)
- **`.gitattributes` forcing LF for `*.sh`** — CRLF checkouts on Windows broke container exec of `docker-entrypoint.sh`
- OpenRouter added to the manual agentic smoke-test matrix

## Testing
- Clean `docker compose build` on node:22; server boots, connects to Postgres
- Live agentic requests verified end-to-end through both `/api/chat/openrouter` (kimi-k3) and `/api/chat/openai` (gpt-4o): tools executed via v7 `ToolLoopAgent`, real arguments persisted to DB
- Non-agentic streaming regression-tested; `tsc` at the pre-existing 67-error baseline (down from ~100 pre-upgrade)

🤖 Generated with [Claude Code](https://claude.com/claude-code)